### PR TITLE
Add a doctest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,13 @@ pub fn modinverse(a: i64, n: i64) -> Option<i64> {
         None
     }
 }
+
+/// # Doctest
+///
+/// ```rust
+/// # use rust_coverage_test::another_function;
+/// let x = another_function().unwrap();
+/// ```
+pub fn another_function() -> Option<i32> {
+    Some(1)
+}


### PR DESCRIPTION
https://github.com/codecov/example-rust says it doesnt include doctest . It would be useful to see which method in this repo does work with a doctest